### PR TITLE
selectors/define.rs: fix outdated target classes

### DIFF
--- a/src/selectors/define.rs
+++ b/src/selectors/define.rs
@@ -16,7 +16,7 @@ pub fn tty(data: &scraper::Html, length_max: usize) {
         .unwrap();
 
     let word = define
-        .select(&Selector::parse("div.c8d6zd.ya2TWb.DgZBFd").unwrap())
+        .select(&Selector::parse("div.c8d6zd.xWMiCc.REww7c").unwrap())
         .next()
         .unwrap()
         .text()
@@ -238,7 +238,7 @@ pub fn raw(data: &scraper::Html) {
         .unwrap();
 
     let word = define
-        .select(&Selector::parse("div.c8d6zd.ya2TWb.DgZBFd").unwrap())
+        .select(&Selector::parse("div.c8d6zd.xWMiCc.REww7c").unwrap())
         .next()
         .unwrap()
         .text()


### PR DESCRIPTION
The `define selector` was panicking. Google has changed the classes for its `define` UI. Updated to new classes. 