### PR TITLE
fixed typo

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ pub fn build<'a>(selectors: &'a [&str]) -> App<'a> {
         .about("please use --help for more detailed information")
         .long_about("trivia on the command line.")
         .version("0.2.0")
-        .help_template("{bin}\n{about}\n\n{usage-heading}\n    {usage}\n\n{all-args}\n\nversion {version} by {author}\nplease report any bugs to https://gitub.com/PureArtistry/oi/issues")
+        .help_template("{bin}\n{about}\n\n{usage-heading}\n    {usage}\n\n{all-args}\n\nversion {version} by {author}\nplease report any bugs to https://github.com/PureArtistry/oi/issues")
 
         .arg(Arg::new("all")
             .short('a')


### PR DESCRIPTION
github URL has typo and gitub.com might have malicious php code